### PR TITLE
Move code from register() to boot()

### DIFF
--- a/src/Latrell/Smarty/SmartyServiceProvider.php
+++ b/src/Latrell/Smarty/SmartyServiceProvider.php
@@ -23,6 +23,13 @@ class SmartyServiceProvider extends ServiceProvider
 		$this->publishes([
 			__DIR__ . '/../../config/config.php' => config_path('latrell-smarty.php')
 		]);
+
+		$this->mergeConfigFrom(__DIR__ . '/../../config/config.php', 'latrell-smarty');
+
+		$this->app['view']->addExtension($this->app['config']->get('latrell-smarty.extension', 'tpl'), 'smarty', function ()
+		{
+			return new SmartyEngine($this->app['config']);
+		});
 	}
 
 	/**
@@ -32,11 +39,5 @@ class SmartyServiceProvider extends ServiceProvider
 	 */
 	public function register()
 	{
-		$this->mergeConfigFrom(__DIR__ . '/../../config/config.php', 'latrell-smarty');
-
-		$this->app['view']->addExtension($this->app['config']->get('latrell-smarty.extension', 'tpl'), 'smarty', function ()
-		{
-			return new SmartyEngine($this->app['config']);
-		});
 	}
 }


### PR DESCRIPTION
As mentioned previously, within the register method, you should only bind things into the service container. You should never attempt to register any event listeners, routes, or any other piece of functionality within the register method. Otherwise, you may accidently use a service that is provided by a service provider which has not loaded yet. (src- http://laravel.com/docs/5.1/providers#the-register-method)